### PR TITLE
fix docs for sub and add and make error message more descriptive

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,9 @@ D.set('milliseconds', 123, date);
 D.set('seconds', 34, date);
 D.set('minutes', 22, date);
 D.set('hours', 13, date);
-D.set('date', 23, date);
-D.set('month', 12, date);
-D.set('year', 2001, date);
+D.set('days', 23, date);
+D.set('months', 12, date);
+D.set('years', 2001, date);
 ```
 
 ### add
@@ -146,9 +146,9 @@ D.add('milliseconds', 123, date);
 D.add('seconds', 34, date);
 D.add('minutes', 22, date);
 D.add('hours', 13, date);
-D.add('date', 23, date);
-D.add('month', 12, date);
-D.add('year', 2001, date);
+D.add('days', 23, date);
+D.add('months', 12, date);
+D.add('years', 2001, date);
 
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "date-fp",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Functional programming date management.",
   "main": "build/date-fp.js",
   "dependencies": {

--- a/src/_spec/add.js
+++ b/src/_spec/add.js
@@ -54,6 +54,11 @@ describe('add', function () {
       assert.equal(actual.toString(), 'Error: Invalid date');
   });
 
+  it('should return an error if the unit of time is invalid', function () {
+    const actual = add('foo', 1, new Date('2015-01-30')).message;
+    assert.equal(actual, 'Unit is invalid, must be one of milliseconds,seconds,minutes,hours,days. Got: foo');
+  });
+
   it('should work for year', function () {
     const actual = add('years', 1, new Date(0));
     assert.equal(1971, actual.getFullYear());

--- a/src/_spec/add.js
+++ b/src/_spec/add.js
@@ -56,7 +56,8 @@ describe('add', function () {
 
   it('should return an error if the unit of time is invalid', function () {
     const actual = add('foo', 1, new Date('2015-01-30')).message;
-    assert.equal(actual, 'Unit is invalid, must be one of milliseconds,seconds,minutes,hours,days. Got: foo');
+    assert.equal(actual,
+        'Unit is invalid, must be one of milliseconds,seconds,minutes,hours,days,months,years. Got: foo');
   });
 
   it('should work for year', function () {

--- a/src/add.js
+++ b/src/add.js
@@ -31,7 +31,7 @@ export default curry((step, count, date) => {
       return _addYear(count, date);
     default:
       if (steps[step] === undefined) {
-        return new Error('Step is invalid');
+        return new Error('Unit is invalid, must be one of ' + Object.keys(steps) + '. Got: ' + step);
       }
       return new Date((steps[step] * count) + date.getTime());
   }

--- a/src/add.js
+++ b/src/add.js
@@ -31,7 +31,7 @@ export default curry((step, count, date) => {
       return _addYear(count, date);
     default:
       if (steps[step] === undefined) {
-        return new Error('Unit is invalid, must be one of ' + Object.keys(steps) + '. Got: ' + step);
+        return new Error('Unit is invalid, must be one of ' + Object.keys(steps) + ',months,years. Got: ' + step);
       }
       return new Date((steps[step] * count) + date.getTime());
   }

--- a/src/get.js
+++ b/src/get.js
@@ -12,7 +12,7 @@ const getters = {
 
 export default curry((prop, date) => {
   if (!getters.hasOwnProperty(prop)) {
-    return new Error('Invalid Date property');
+    return new Error('Invalid Date property, must be one of ' + Object.keys(getters) + '.');
   }
   return getters[prop](date);
 });


### PR DESCRIPTION
Docs gave incorrect time units for `D.add` and `D.sub`. Error messages weren't very descriptive so they now give the user a list of of the valid units.
