### PR TITLE
Add istanbul code coverge tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "webpack": "webpack src/index.js build/date-fp.js --config webpack.config.js",
     "uglify": "uglifyjs build/date-fp.js -o build/date-fp.min.js --source-map build/date-fp.min.map -p relative",
     "build": "npm run webpack && npm run uglify",
-    "test": "mocha --compilers js:babel/register 'src/**/_spec/*.js'",
-    "test:coverage": "istanbul cover _mocha -- --compilers js:babel/register 'src/**/_spec/*.js'",
+    "test": "istanbul cover _mocha -- --compilers js:babel/register 'src/**/_spec/*.js' && istanbul check-coverage --branches 100",
     "testBuild": "mocha buildTest.js",
     "watch": "mocha --watch --compilers js:babel/register 'src/**/_spec/*.js'"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "date-fp",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Functional programming date management.",
   "main": "build/date-fp.js",
   "dependencies": {
@@ -11,6 +11,7 @@
     "uglify": "uglifyjs build/date-fp.js -o build/date-fp.min.js --source-map build/date-fp.min.map -p relative",
     "build": "npm run webpack && npm run uglify",
     "test": "mocha --compilers js:babel/register 'src/**/_spec/*.js'",
+    "test:coverage": "istanbul cover _mocha -- --compilers js:babel/register 'src/**/_spec/*.js'",
     "testBuild": "mocha buildTest.js",
     "watch": "mocha --watch --compilers js:babel/register 'src/**/_spec/*.js'"
   },
@@ -23,6 +24,7 @@
     "babel-loader": "^5.3.2",
     "eslint": "^1.7.1",
     "eslint-plugin-react": "^3.6.2",
+    "istanbul": "^0.4.0",
     "mocha": "^2.3.3",
     "uglifyjs": "^2.4.10",
     "webpack": "^1.12.2"

--- a/src/_spec/format.js
+++ b/src/_spec/format.js
@@ -98,8 +98,16 @@ describe('format', function () {
     assert.equal(format('A', new Date('2015-03-04 22:08:05.023')), 'PM');
   });
 
+  it('A', function () {
+    assert.equal(format('A', new Date('2015-03-04 11:08:05.023')), 'AM');
+  });
+
   it('a', function () {
     assert.equal(format('a', new Date('2015-03-04 22:08:05.023')), 'pm');
+  });
+
+  it('a', function () {
+    assert.equal(format('a', new Date('2015-03-04 11:08:05.023')), 'am');
   });
 
   it('SSS', function () {

--- a/src/_spec/get.js
+++ b/src/_spec/get.js
@@ -8,6 +8,13 @@ describe('get', function () {
     assert.equal(get('seconds')(date), get('seconds', date));
   });
 
+  it('should return an error for an invalid time unit', function () {
+    const input = new Date('2015-01-02 11:22:33.123');
+    const errorMsg = get('foo', input).message;
+    assert.equal(errorMsg,
+        'Invalid Date property, must be one of milliseconds,seconds,minutes,hours,date,month,year.');
+  });
+
   it('should return the milliseconds', function () {
     const input = new Date('2015-01-02 11:22:33.123');
     const milliseconds = get('milliseconds', input);

--- a/src/_spec/isValid.js
+++ b/src/_spec/isValid.js
@@ -4,6 +4,10 @@ import isValid from '../isValid';
 
 describe('isValid', () => {
 
+    it('should return false for non date objects', () => {
+        assert.strictEqual(isValid('date'), false);
+    });
+
     it('should identify invalid dates', () => {
         const invalidDate = new Date('foo');
         const invalidDate1 = new Date('19-16-2011');

--- a/src/_spec/set.js
+++ b/src/_spec/set.js
@@ -14,6 +14,12 @@ describe('set', function () {
       assert.deepEqual(set('seconds')(5)(date), set('seconds', 5, date));
   });
 
+    it('should return an error for an invalid time unit', function () {
+        const input = new Date('2015-01-02 11:22:33.123');
+        const errorMsg = set('foo', 0, input).message;
+        assert.equal(errorMsg, 'foo is not a valid date step');
+    });
+
   it('should not change the original date', function () {
       const input = new Date('2015-01-01 11:22:33.333');
       set('milliseconds', 0, input);

--- a/src/format.js
+++ b/src/format.js
@@ -28,7 +28,7 @@ const tokenFunctions = {
   a:    d => d.getHours() > 11 ? 'pm': 'am',
   SSS:  d => fill(3, d.getMilliseconds()),
   SS:   d => firstN(2, fill(3, d.getMilliseconds())),
-  S:    d => firstN(1, fill(3, d.getMilliseconds())),
+  S:    d => firstN(1, fill(3, d.getMilliseconds()))
 };
 
 const swapTokenWithValue = curry((date, token) => tokenFunctions[token] ? tokenFunctions[token](date): token);

--- a/src/set.js
+++ b/src/set.js
@@ -9,12 +9,12 @@ const setters = {
   'hours': (value, date) => date.setHours(value),
   'date': (value, date) => date.setDate(value),
   'month': (value, date) => date.setMonth(value - 1),
-  'year': (value, date) => date.setFullYear(value),
+  'year': (value, date) => date.setFullYear(value)
 };
 
 export default curry((step, value, date) => {
   if(!setters.hasOwnProperty(step)) {
-    return new Error(step + 'is not a valid date step');
+    return new Error(step + ' is not a valid date step');
   }
   let clone = new Date(date.getTime());
   setters[step](value, clone);


### PR DESCRIPTION
Added Istanbul for code coverage stats and added the requisite test cases to turn this:

```
=============================== Coverage summary ===============================
Statements   : 99.47% ( 560/563 )
Branches     : 96.12% ( 124/129 ), 23 ignored
Functions    : 100% ( 180/180 )
Lines        : 99.63% ( 536/538 )
================================================================================
```

Into this:

```
=============================== Coverage summary ===============================
Statements   : 100% ( 577/577 )
Branches     : 100% ( 129/129 ), 23 ignored
Functions    : 100% ( 185/185 )
Lines        : 100% ( 552/552 )
================================================================================

```

I wasn't sure whether to make `npm test` run code coverage and fail if coverage went below 100 percent though so I just added a new script called `test:coverage`. Thoughts?
