### PR TITLE
consolidate date validation in one function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "date-fp",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Functional programming date management.",
   "main": "build/date-fp.js",
   "dependencies": {

--- a/src/_spec/convertTo.js
+++ b/src/_spec/convertTo.js
@@ -15,7 +15,7 @@ describe('convertTo', () => {
     });
 
     it('should return an error for invalid dates', () => {
-        assert.equal(convertTo('seconds', new Date('foo')).message, 'Invalid date object provided.');
+        assert.equal(convertTo('seconds', new Date('foo')).message, 'Invalid date object(s) provided.');
     });
 
     it('should return the time in milliseconds for valid dates', () => {

--- a/src/_spec/equals.js
+++ b/src/_spec/equals.js
@@ -8,15 +8,15 @@ describe('equals', () => {
     const invalidDate = new Date('foo');
 
     it('should return an Error when given two invalid dates', () => {
-        assert.equal(equals(invalidDate, new Date('bar')).message, 'The two valid dates must be supplied.');
+        assert.equal(equals(invalidDate, new Date('bar')).message, 'Invalid date object(s) provided.');
     });
 
     it('should return an Error for a date and an invalid date', () => {
-        assert.equal(equals(date, new Date('bar')).message, 'The two valid dates must be supplied.');
+        assert.equal(equals(date, new Date('bar')).message, 'Invalid date object(s) provided.');
     });
 
     it('should return an Error for an invalid date and an invalid date', () => {
-        assert.equal(equals(new Date('bar'), date).message, 'The two valid dates must be supplied.');
+        assert.equal(equals(new Date('bar'), date).message, 'Invalid date object(s) provided.');
     });
 
     it('should return false for different dates', () => {

--- a/src/_spec/isLeapYear.js
+++ b/src/_spec/isLeapYear.js
@@ -5,7 +5,7 @@ import isLeapYear from '../isLeapYear';
 describe('isLeapYear', () => {
 
     it('should return an error for an invalid date', () => {
-        assert.equal(isLeapYear(new Date('2015-33-33')).message, 'Invalid date object provided.');
+        assert.equal(isLeapYear(new Date('2015-33-33')).message, 'Invalid date object(s) provided.');
     });
 
     it('should return false for non leap years', () => {

--- a/src/_spec/max.js
+++ b/src/_spec/max.js
@@ -23,8 +23,8 @@ describe('max', () => {
     });
 
     it('should return an error when passed only invalid dates', () => {
-        assert.equal(max([]).message, 'No valid dates provided.');
-        assert.equal(max([invalidDate, invalidDate1]).message, 'No valid dates provided.');
+        assert.equal(max([]).message, 'Invalid date object(s) provided.');
+        assert.equal(max([invalidDate, invalidDate1]).message, 'Invalid date object(s) provided.');
     });
 
 });

--- a/src/_spec/min.js
+++ b/src/_spec/min.js
@@ -23,8 +23,8 @@ describe('min', () => {
     });
 
     it('should return an error when passed only invalid dates', () => {
-        assert.equal(min([]).message, 'No valid dates provided.');
-        assert.equal(min([invalidDate, invalidDate1]).message, 'No valid dates provided.');
+        assert.equal(min([]).message, 'Invalid date object(s) provided.');
+        assert.equal(min([invalidDate, invalidDate1]).message, 'Invalid date object(s) provided.');
     });
 
 });

--- a/src/_spec/unixTime.js
+++ b/src/_spec/unixTime.js
@@ -5,7 +5,7 @@ import unixTime from '../unixTime';
 describe('unixTime', () => {
 
     it('should return an error for invalid dates', () => {
-        assert.equal(unixTime(new Date('foo')).message, 'Invalid date object provided.');
+        assert.equal(unixTime(new Date('foo')).message, 'Invalid date object(s) provided.');
     });
 
     it('should return the time in seconds for valid dates', () => {

--- a/src/convertTo.js
+++ b/src/convertTo.js
@@ -1,12 +1,13 @@
 'use strict';
 import curry from 'lodash.curry';
-import isValid from './isValid';
+import {check} from './helpers/util';
 import {DATE_UNITS} from './helpers/constants';
+
+const convertTo = (unit, date) => Math.round(date.getTime() / DATE_UNITS[unit]);
 
 export default curry((unit, date) => {
     if (!DATE_UNITS.hasOwnProperty(unit)) {
         return new Error('Unit provided must be one of ' + Object.keys(DATE_UNITS) + '.');
     }
-    return isValid(date) ? Math.round(date.getTime() / DATE_UNITS[unit]) :
-        new Error('Invalid date object provided.');
+    return check([date], convertTo, unit, date);
 });

--- a/src/equals.js
+++ b/src/equals.js
@@ -1,8 +1,7 @@
 'use strict';
 import curry from 'lodash.curry';
-import isValid from './isValid';
+import {check} from './helpers/util';
 
-export default curry((d1, d2) => {
-    if(!isValid(d1) || !isValid(d2)) return new Error('The two valid dates must be supplied.');
-    return d1.getTime() === d2.getTime();
-});
+const equals = (d1, d2) => d1.getTime() === d2.getTime();
+
+export default curry((d1, d2) => check([d1, d2], equals, d1, d2));

--- a/src/helpers/util.js
+++ b/src/helpers/util.js
@@ -13,3 +13,7 @@ export const find = curry((f, array) => {
     return validDates.length === 0 ? new Error('No valid dates provided.') :
         new Date(validDates.reduce((memo, date) => f(memo, date)));
 });
+
+export const validate = dates => dates.filter(isValid).length === dates.length;
+
+export const check = (dates, f, ...args) => validate(dates) ? f(...args) : new Error('Invalid date object(s) provided.');

--- a/src/helpers/util.js
+++ b/src/helpers/util.js
@@ -9,11 +9,10 @@ export const firstN = curry((n, str) => str.substring(0, n));
 export const fill = curry((digits, n) => lastN(digits, ZEROS + n));
 
 export const find = curry((f, array) => {
-    let validDates = array.filter(isValid);
-    return validDates.length === 0 ? new Error('No valid dates provided.') :
-        new Date(validDates.reduce((memo, date) => f(memo, date)));
+    let filtered = array.filter(isValid);
+    return check(filtered, dates => new Date(dates.reduce((memo, date) => f(memo, date))), filtered)
 });
 
-export const validate = dates => dates.filter(isValid).length === dates.length;
+export const validate = dates => dates.length > 0 && dates.filter(isValid).length === dates.length;
 
 export const check = (dates, f, ...args) => validate(dates) ? f(...args) : new Error('Invalid date object(s) provided.');

--- a/src/isLeapYear.js
+++ b/src/isLeapYear.js
@@ -1,8 +1,7 @@
 'use strict';
 import curry from 'lodash.curry';
-import isValid from './isValid';
+import {check} from './helpers/util';
 
-export default curry((date) => {
-    return isValid(date) ? new Date(date.getFullYear() + '-02-29').getMonth() === 1 :
-        new Error('Invalid date object provided.');
-});
+const isLeapYear = date => new Date(date.getFullYear() + '-02-29').getMonth() === 1;
+
+export default curry((date) => check([date], isLeapYear, date));


### PR DESCRIPTION
The `min` and `max`  functions work differently to the other functions because they ignore invalid dates if at least one valid date has been provided. This makes the underlying `find` function they're implemented with look a bit odd as it now sanitises the data twice. It should probably work like the other functions in the library and return an error if any of the dates are invalid but that would be a breaking change. I would prefer if there was no error handling logic in any of these functions.
