### PR TITLE
readme: use "Boolean" rather than "bool" in type signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ const date = D.clone(new Date('2015-01-01')); // Thu Jan 01 2015 00:00:00 GMT+00
 ```
 
 ### isValid
-`Date -> bool`
+`Date -> Boolean`
 
 Verifies if a specific Javascript date object is valid.
 
@@ -94,7 +94,7 @@ D.get('year', date); // 2015
 ```
 
 ### isLeapYear
-`Date -> bool | Error`
+`Date -> Boolean | Error`
 
 Verifies if the year of the date object supplied is a leap year. Returns an error if
 the date object is invalid.
@@ -185,7 +185,7 @@ D.sub('year', 2001, date);
 ```
 
 ### equals
-`Date -> Date -> bool | Error`
+`Date -> Date -> Boolean | Error`
 
 Uses value equality to determine if the two supplied dates are the same.
 Returns an error if any of the date objects are invalid.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "date-fp",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Functional programming date management.",
   "main": "build/date-fp.js",
   "dependencies": {


### PR DESCRIPTION
It seems to me the name of the type should be capitalized, and should be `Boolean` rather than `Bool` to match the name of the constructor.
