### PR TITLE
Return Invalid Date / NaN instead of Errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ D.isValid(d1); // true
 ### get
 `String -> Date -> Date | Error`
 
-Returns the chosen portion of a date. Returns an error if the provided unit of time is not valid.
+Returns the chosen portion of a date. Returns an `Invalid Date` if the provided unit of time is not valid.
 
 ```js
 const date = new Date('2015-01-02 11:22:33.444')
@@ -96,7 +96,7 @@ D.get('year', date); // 2015
 ### isLeapYear
 `Date -> Boolean | Error`
 
-Verifies if the year of the date object supplied is a leap year. Returns an error if
+Verifies if the year of the date object supplied is a leap year. Returns `false` if
 the date object is invalid.
 
 ```js
@@ -109,7 +109,7 @@ D.isLeapYear(new Date('2004-01-01') // true
 
 Returns the time since the Unix epoch, in the specified unit (milliseconds, seconds, minutes, hours, days),
 of the supplied Javascript date object.
-Returns an error if the unit of time or Javascript date object is not valid.
+Returns `NaN` if the unit of time or Javascript date object is not valid.
 
 ```js
 const date = new Date('2015-10-16T00:00:00+00:00')
@@ -124,7 +124,7 @@ D.convertTo('days', date) // 16724
 `Date -> Number | Error`
 
 Returns the time since the Unix epoch in seconds of the supplied Javascript date object
-Returns an error if the Javascript date object is not valid.
+Returns `NaN` if the Javascript date object is not valid.
 
 ```js
 const date = new Date('2015-10-16T00:00:00+00:00')
@@ -134,8 +134,8 @@ D.unixTime(date) // 1444996800
 ### set
 `String -> Number -> Date -> Date | Error`
 
-Returns a clone of the supplied date with the specified modification.
-Returns an Error if the modification results in an invalid date.
+Returns a copy of the supplied date with the specified modification.
+Returns an `Invalid Date` if the modification results in an invalid date.
 
 ```js
 const date = new Date();
@@ -151,8 +151,8 @@ D.set('years', 2001, date);
 ### add
 `String -> Number -> Date -> Date | Error`
 
-Returns a clone of the supplied date with the specified modification.
-Returns an Error if the modification results in an invalid date.
+Returns a copy of the supplied date with the specified modification.
+Returns an `Invalid Date` if the modification results in an invalid date.
 
 ```js
 const date = new Date();
@@ -169,8 +169,8 @@ D.add('years', 2001, date);
 ### sub
 `String -> Number -> Date -> Date | Error`
 
-Returns a clone of the supplied date with the specified modification.
-Returns an Error if the modification results in an invalid date.
+Returns a copy of the supplied date with the specified modification.
+Returns an `Invalid Date` if the modification results in an invalid date.
 
 ```js
 const date = new Date();
@@ -188,7 +188,7 @@ D.sub('year', 2001, date);
 `Date -> Date -> Boolean | Error`
 
 Uses value equality to determine if the two supplied dates are the same.
-Returns an error if any of the date objects are invalid.
+Returns `false` if any of the date objects are invalid.
 
 ```js
 const date = new Date('2015-04-09');
@@ -201,7 +201,7 @@ D.equals(date, new Date('2014-01-01')); //false
 `String -> Date -> Date -> Number | Error`
 
 Returns the difference between two dates.
-Returns an Error if given an invalid date unit.
+Returns `NaN` if given an invalid date unit.
 
 ```js
 const date1 = new Date('2014-02-01 11:12:13.123');
@@ -219,7 +219,7 @@ D.diff('years', date1, new Date('2015-04-01 11:12:13.123')); // 1
 `[Date] -> Date | Error`
 
 Takes an array of dates and returns the oldest one. Ignores invalid Javascript date objects and returns
-an error if no valid date objects are provided.
+an `Invalid Date` if no valid date objects are provided.
 
 ```js
 const date1 = new Date('2015-01-01 11:22:33.333');
@@ -236,7 +236,7 @@ D.min([invalidDate]); // Error
 `[Date] -> Date | Error`
 
 Takes an array of dates and returns the latest one. Ignores invalid Javascript date objects and returns
-an error if no valid date objects are provided.
+an `Invalid Date` if no valid date objects are provided.
 
 ```js
 const date1 = new Date('2015-01-01 11:22:33.333');
@@ -251,7 +251,7 @@ D.max([invalidDate]); // Error
 ### format
 `String -> Date -> String`
 
-Returns a string representation of a date on the specified format
+Returns a string representation of a date on the specified format. Returns the string 'Invalid Date' if given an invalid date.
 
 ```js
 const date = new Date('2015-01-02 03:04:05.123');

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ D.isValid(d1); // true
 ```
 
 ### get
-`String -> Date -> Date | Error`
+`String -> Date -> Date`
 
 Returns the chosen portion of a date. Returns an `Invalid Date` if the provided unit of time is not valid.
 
@@ -94,7 +94,7 @@ D.get('year', date); // 2015
 ```
 
 ### isLeapYear
-`Date -> Boolean | Error`
+`Date -> Boolean`
 
 Verifies if the year of the date object supplied is a leap year. Returns `false` if
 the date object is invalid.
@@ -105,7 +105,7 @@ D.isLeapYear(new Date('2004-01-01') // true
 ```
 
 ### convertTo
-`String -> Date -> Number | Error`
+`String -> Date -> Number`
 
 Returns the time since the Unix epoch, in the specified unit (milliseconds, seconds, minutes, hours, days),
 of the supplied Javascript date object.
@@ -121,7 +121,7 @@ D.convertTo('days', date) // 16724
 ```
 
 ### unixTime
-`Date -> Number | Error`
+`Date -> Number`
 
 Returns the time since the Unix epoch in seconds of the supplied Javascript date object
 Returns `NaN` if the Javascript date object is not valid.
@@ -132,7 +132,7 @@ D.unixTime(date) // 1444996800
 ```
 
 ### set
-`String -> Number -> Date -> Date | Error`
+`String -> Number -> Date -> Date`
 
 Returns a copy of the supplied date with the specified modification.
 Returns an `Invalid Date` if the modification results in an invalid date.
@@ -149,7 +149,7 @@ D.set('years', 2001, date);
 ```
 
 ### add
-`String -> Number -> Date -> Date | Error`
+`String -> Number -> Date -> Date`
 
 Returns a copy of the supplied date with the specified modification.
 Returns an `Invalid Date` if the modification results in an invalid date.
@@ -167,7 +167,7 @@ D.add('years', 2001, date);
 ```
 
 ### sub
-`String -> Number -> Date -> Date | Error`
+`String -> Number -> Date -> Date`
 
 Returns a copy of the supplied date with the specified modification.
 Returns an `Invalid Date` if the modification results in an invalid date.
@@ -185,7 +185,7 @@ D.sub('year', 2001, date);
 ```
 
 ### equals
-`Date -> Date -> Boolean | Error`
+`Date -> Date -> Boolean`
 
 Uses value equality to determine if the two supplied dates are the same.
 Returns `false` if any of the date objects are invalid.
@@ -198,7 +198,7 @@ D.equals(date, new Date('2014-01-01')); //false
 
 ### diff
 
-`String -> Date -> Date -> Number | Error`
+`String -> Date -> Date -> Number`
 
 Returns the difference between two dates.
 Returns `NaN` if given an invalid date unit.
@@ -216,7 +216,7 @@ D.diff('years', date1, new Date('2015-04-01 11:12:13.123')); // 1
 
 ### min
 
-`[Date] -> Date | Error`
+`[Date] -> Date`
 
 Takes an array of dates and returns the oldest one. Ignores invalid Javascript date objects and returns
 an `Invalid Date` if no valid date objects are provided.
@@ -233,7 +233,7 @@ D.min([invalidDate]); // Error
 
 ### max
 
-`[Date] -> Date | Error`
+`[Date] -> Date`
 
 Takes an array of dates and returns the latest one. Ignores invalid Javascript date objects and returns
 an `Invalid Date` if no valid date objects are provided.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "date-fp",
-  "version": "1.6.5",
+  "version": "2.0.0",
   "description": "Functional programming date management.",
   "main": "build/date-fp.js",
   "dependencies": {
@@ -11,7 +11,7 @@
     "uglify": "uglifyjs build/date-fp.js -o build/date-fp.min.js --source-map build/date-fp.min.map -p relative",
     "build": "npm run webpack && npm run uglify",
     "test": "babel-node node_modules/.bin/isparta cover _mocha -- --compilers js:babel-register 'src/**/_spec/*.js'",
-    "posttest" :"istanbul check-coverage --branches 100",
+    "posttest": "istanbul check-coverage --branches 100",
     "testBuild": "mocha buildTest.js",
     "watch": "mocha --watch --compilers js:babel-register 'src/**/_spec/*.js'"
   },

--- a/sandbox.js
+++ b/sandbox.js
@@ -1,12 +1,5 @@
 'use strict';
-import D from './index';
-const date1 = new Date('2014-02-01 11:12:13.123');
-const date2 = new Date('2015-01-03 21:12:13.123');
-
-console.log(D.diff('milliseconds', date1, date2));
-console.log(D.diff('seconds', date1, date2));
-console.log(D.diff('minutes', date1, date2));
-console.log(D.diff('hours', date1, date2));
-console.log(D.diff('days', date1, date2));
-console.log(D.diff('months', date1, date2));
-console.log(D.diff('years', date1, date2));
+import D from './src';
+import {any} from './src/helpers/util'
+import isValid from './src/isValid'
+console.log(any(isValid, [1, 2, 3]))

--- a/sandbox.js
+++ b/sandbox.js
@@ -1,5 +1,0 @@
-'use strict';
-import D from './src';
-import {any} from './src/helpers/util'
-import isValid from './src/isValid'
-console.log(any(isValid, [1, 2, 3]))

--- a/src/_spec/add.js
+++ b/src/_spec/add.js
@@ -1,6 +1,8 @@
 /* eslint max-statements:0 */
 import assert from 'assert'
 import add from '../add'
+import isValid from '../isValid'
+import {checkDate} from '../helpers/util'
 const SECOND = 1000
 const MINUTE = 60 * SECOND
 const HOUR = 60 * MINUTE
@@ -61,10 +63,11 @@ describe('add', () => {
     assert.equal(1, actual.getMonth())
   })
 
-  it('should return an error if the result is invalid', () => {
+  it('should return an invalid date if the result is invalid', () => {
     const actual = add('months', 1, new Date('2015-01-30'))
 
-    assert.equal(actual.toString(), 'Error: Invalid date')
+    assert(checkDate(actual))
+    assert(!isValid(actual))
   })
 
   it('should return an error if the unit of time is invalid', () => {

--- a/src/_spec/convertTo.js
+++ b/src/_spec/convertTo.js
@@ -1,5 +1,6 @@
 import assert from 'assert'
 import convertTo from '../convertTo'
+import {checkNaN} from '../helpers/util'
 
 describe('convertTo', () => {
   const date = new Date('December 28, 1973')
@@ -8,14 +9,12 @@ describe('convertTo', () => {
     assert.equal(convertTo('milliseconds')(date), convertTo('milliseconds', date))
   })
 
-  it('should return an error for invalid units', () => {
-    assert.equal(
-      convertTo('foo', date).message,
-      'Unit provided must be one of milliseconds,seconds,minutes,hours,days.')
+  it('should return NaN for invalid units', () => {
+    assert(checkNaN(convertTo('foo', date)))
   })
 
-  it('should return an error for invalid dates', () => {
-    assert.equal(convertTo('seconds', new Date('foo')).message, 'Invalid date object(s) provided.')
+  it('should return NaN for invalid dates', () => {
+    assert(checkNaN(convertTo('seconds', new Date('foo'))))
   })
 
   it('should return the time in milliseconds for valid dates', () => {

--- a/src/_spec/diff.js
+++ b/src/_spec/diff.js
@@ -1,4 +1,5 @@
 import assert from 'assert'
+import {checkNaN} from '../helpers/util'
 import diff from '../diff'
 const date1 = new Date('2013-01-02 11:22:33.123')
 
@@ -9,11 +10,10 @@ describe('diff', () => {
     assert.equal(diff('milliseconds')(date1)(date2), diff('milliseconds', date1, date2))
   })
 
-  it('should return an error if given an invalid unit', () => {
+  it('should return NaN when given an invalid unit', () => {
     const date2 = new Date('2013-01-02 11:22:33.223')
 
-    assert.deepEqual(diff('invalid', date1, date2), new Error('Invalid date unit'))
-    assert.equal(diff('invalid', date1, date2).message, 'Invalid date unit')
+    assert(checkNaN(diff('invalid', date1, date2)))
   })
 
   it('milliseconds', () => {

--- a/src/_spec/equals.js
+++ b/src/_spec/equals.js
@@ -6,16 +6,16 @@ describe('equals', () => {
   const date = new Date('2011-06-19 18:40:33.333')
   const invalidDate = new Date('foo')
 
-  it('should return an Error when given two invalid dates', () => {
-    assert.equal(equals(invalidDate, new Date('bar')).message, 'Invalid date object(s) provided.')
+  it('should return false when given two invalid dates', () => {
+    assert.equal(equals(invalidDate, new Date('bar')), false)
   })
 
-  it('should return an Error for a date and an invalid date', () => {
-    assert.equal(equals(date, new Date('bar')).message, 'Invalid date object(s) provided.')
+  it('should return an false for a date and an invalid date', () => {
+    assert.equal(equals(date, new Date('bar')), false)
   })
 
-  it('should return an Error for an invalid date and an invalid date', () => {
-    assert.equal(equals(new Date('bar'), date).message, 'Invalid date object(s) provided.')
+  it('should return an false for an invalid date and an invalid date', () => {
+    assert.equal(equals(new Date('bar'), date), false)
   })
 
   it('should return false for different dates', () => {

--- a/src/_spec/format.js
+++ b/src/_spec/format.js
@@ -15,6 +15,10 @@ describe('format', () => {
     assert.equal(format(str)(date), format(str, date))
   })
 
+  it('should return "invalid date" if given an invalid date', () => {
+    assert.equal(format('YYYY-MM-DD')(new Date('invalid')), 'Invalid Date')
+  })
+
   it('YYYY', () => {
     assert.equal(format('YYYY', date), '2015')
   })

--- a/src/_spec/get.js
+++ b/src/_spec/get.js
@@ -1,4 +1,5 @@
 import assert from 'assert'
+import {checkNaN} from '../helpers/util'
 import get from '../get'
 
 describe('get', () => {
@@ -8,12 +9,11 @@ describe('get', () => {
     assert.equal(get('seconds')(date), get('seconds', date))
   })
 
-  it('should return an error for an invalid time unit', () => {
+  it('should return NaN for an invalid time unit', () => {
     const input = new Date('2015-01-02 11:22:33.123')
-    const errorMsg = get('foo', input).message
+    const actual = get('foo', input)
 
-    assert.equal(errorMsg,
-        'Invalid Date property, must be one of milliseconds,seconds,minutes,hours,date,month,year.')
+    assert(checkNaN(actual))
   })
 
   it('should return the milliseconds', () => {

--- a/src/_spec/isLeapYear.js
+++ b/src/_spec/isLeapYear.js
@@ -3,8 +3,8 @@ import isLeapYear from '../isLeapYear'
 
 describe('isLeapYear', () => {
 
-  it('should return an error for an invalid date', () => {
-    assert.equal(isLeapYear(new Date('2015-33-33')).message, 'Invalid date object(s) provided.')
+  it('should return false for an invalid date', () => {
+    assert.equal(isLeapYear(new Date('2015-33-33')), false)
   })
 
   it('should return false for non leap years', () => {

--- a/src/_spec/max.js
+++ b/src/_spec/max.js
@@ -1,5 +1,7 @@
 import assert from 'assert'
 import max from '../max'
+import {checkDate} from '../helpers/util'
+import isValid from '../isValid'
 
 describe('max', () => {
 
@@ -21,9 +23,17 @@ describe('max', () => {
     assert.equal(max([invalidDate, maxDate1, maxDate2, date1, invalidDate1]).toString(), maxDate2.toString())
   })
 
-  it('should return an error when passed only invalid dates', () => {
-    assert.equal(max([]).message, 'Invalid date object(s) provided.')
-    assert.equal(max([invalidDate, invalidDate1]).message, 'Invalid date object(s) provided.')
+  it('should return an invalid date when passed no dates', () => {
+    const actual = max([])
+
+    assert(checkDate(actual))
+    assert.equal(isValid(actual), false)
+  })
+  it('should return an invalid date when passed no dates', () => {
+    const actual = max([invalidDate, invalidDate1])
+
+    assert(checkDate(actual))
+    assert.equal(isValid(actual), false)
   })
 
 })

--- a/src/_spec/min.js
+++ b/src/_spec/min.js
@@ -1,6 +1,6 @@
 import assert from 'assert'
 import min from '../min'
-
+import isValid from '../isValid'
 describe('min', () => {
 
   const minDate1 = new Date('2015-01-01 11:22:33.333')
@@ -21,9 +21,15 @@ describe('min', () => {
     assert.equal(min([invalidDate, minDate1, minDate2, date1, invalidDate1]).toString(), minDate2.toString())
   })
 
-  it('should return an error when passed only invalid dates', () => {
-    assert.equal(min([]).message, 'Invalid date object(s) provided.')
-    assert.equal(min([invalidDate, invalidDate1]).message, 'Invalid date object(s) provided.')
+  it('should return an invalid date when passed no dates', () => {
+    const actual = min([])
+
+    assert.equal(isValid(actual), false)
+  })
+  it('should return an invalid date when passed no dates', () => {
+    const actual = min([invalidDate, invalidDate1])
+
+    assert.equal(isValid(actual), false)
   })
 
 })

--- a/src/_spec/set.js
+++ b/src/_spec/set.js
@@ -1,6 +1,8 @@
 /* eslint max-statements:0 */
 import assert from 'assert'
 import set from '../set'
+import isValid from '../isValid'
+import {checkDate} from '../helpers/util'
 
 describe('set', () => {
   it('should return a new date', () => {
@@ -16,11 +18,12 @@ describe('set', () => {
     assert.deepEqual(set('seconds')(5)(date), set('seconds', 5, date))
   })
 
-  it('should return an error for an invalid time unit', () => {
+  it('should return an invalid date for an invalid time unit', () => {
     const input = new Date('2015-01-02 11:22:33.123')
-    const errorMsg = set('foo', 0, input).message
+    const actual = set('foo', 0, input)
 
-    assert.equal(errorMsg, 'foo is not a valid date step')
+    assert(checkDate(actual))
+    assert.equal(isValid(actual), false)
   })
 
   it('should not change the original date', () => {
@@ -65,11 +68,12 @@ describe('set', () => {
     assert.equal(actual.getDate(), 12)
   })
 
-  it('should return an error if given an invalid date', () => {
+  it('should return an invalid date if given an invalid date', () => {
     const input = new Date('2015-02-01 11:22:33.333')
     const actual = set('date', 30, input)
 
-    assert.equal(actual.toString(), 'Error: Invalid value for date')
+    assert(checkDate(actual))
+    assert.equal(isValid(actual), false)
   })
 
   it('should work for month', () => {
@@ -79,11 +83,12 @@ describe('set', () => {
     assert.equal(actual.getMonth() + 1, 12)
   })
 
-  it('should return an error if given an invalid month', () => {
+  it('should return an invalid date if given an invalid month', () => {
     const input = new Date('2015-02-01 11:22:33.333')
     const actual = set('month', 13, input)
 
-    assert.equal(actual.toString(), 'Error: Invalid value for month')
+    assert(checkDate(actual))
+    assert.equal(isValid(actual), false)
   })
 
   it('should work for year', () => {

--- a/src/_spec/unixTime.js
+++ b/src/_spec/unixTime.js
@@ -1,10 +1,11 @@
 import assert from 'assert'
 import unixTime from '../unixTime'
+import {checkNaN} from '../helpers/util'
 
 describe('unixTime', () => {
 
-  it('should return an error for invalid dates', () => {
-    assert.equal(unixTime(new Date('foo')).message, 'Invalid date object(s) provided.')
+  it('should return NaN for invalid dates', () => {
+    assert(checkNaN(unixTime(new Date('foo'))))
   })
 
   it('should return the time in seconds for valid dates', () => {

--- a/src/add.js
+++ b/src/add.js
@@ -13,7 +13,7 @@ const _addMonth = (count, date) => {
 
   clone.setMonth(date.getMonth() + count)
   if (clone.getMonth() !== (date.getMonth() + count) % 12) {
-    return new Error('Invalid date')
+    return new Date('invalid')
   }
   return clone
 }

--- a/src/convertTo.js
+++ b/src/convertTo.js
@@ -1,12 +1,12 @@
 import curry from 'lodash.curry'
-import {check} from './helpers/util'
+import isValid from './isValid'
 import {DATE_UNITS} from './helpers/constants'
 
 const convertTo = (unit, date) => Math.round(date.getTime() / DATE_UNITS[unit])
 
 export default curry((unit, date) => {
   if (!DATE_UNITS.hasOwnProperty(unit)) {
-    return new Error(`Unit provided must be one of ${Object.keys(DATE_UNITS)}.`)
+    return NaN
   }
-  return check([date], convertTo, unit, date)
+  return isValid(date) ? convertTo(unit, date) : NaN
 })

--- a/src/diff.js
+++ b/src/diff.js
@@ -12,9 +12,7 @@ export default curry((unit, date1, date2) => {
       (get('month', date2) - get('month', date1))
   }
 
-  if (!DATE_UNITS[unit]) {
-    return Error('Invalid date unit')
-  }
+  if (!DATE_UNITS[unit]) return NaN
 
   return Math.round((date2 - date1) / DATE_UNITS[unit])
 })

--- a/src/equals.js
+++ b/src/equals.js
@@ -1,6 +1,3 @@
 import curry from 'lodash.curry'
-import {check} from './helpers/util'
 
-const equals = (d1, d2) => d1.getTime() === d2.getTime()
-
-export default curry((d1, d2) => check([d1, d2], equals, d1, d2))
+export default curry((d1, d2) => d1.getTime() === d2.getTime())

--- a/src/format.js
+++ b/src/format.js
@@ -1,6 +1,7 @@
 import curry from 'lodash.curry'
 import {DATE_TOKENS, WEEKDAYS, MONTHS} from './helpers/constants'
 import {fill, firstN, lastN} from './helpers/util'
+import isValid from './isValid'
 
 const tokenFunctions = {
   YYYY: d => fill(4, d.getFullYear()),
@@ -34,6 +35,8 @@ const tokenFunctions = {
 const swapTokenWithValue = curry((date, token) => tokenFunctions[token] ? tokenFunctions[token](date) : token)
 
 export default curry((format, date) => {
+  if (isValid(date) === false) return 'Invalid Date'
+
   return format.match(DATE_TOKENS)
     .map(swapTokenWithValue(date))
     .join('')

--- a/src/get.js
+++ b/src/get.js
@@ -10,9 +10,7 @@ const getters = {
 }
 
 export default curry((prop, date) => {
-  if (!getters.hasOwnProperty(prop)) {
-    return new Error(`Invalid Date property, must be one of ${Object.keys(getters)}.`)
-  }
+  if (!getters.hasOwnProperty(prop)) return NaN
 
   return getters[prop](date)
 })

--- a/src/helpers/util.js
+++ b/src/helpers/util.js
@@ -15,6 +15,7 @@ export const find = curry((f, array) => {
 
   return check(filtered, dates => new Date(dates.reduce((memo, date) => f(memo, date))), filtered)
 })
+export const any = curry((f, coll) => coll.reduce((r, e) => r || f(e), false))
 
 
 export const checkNaN = n => n !== n // NaN is the only number that is not equal to itself

--- a/src/isLeapYear.js
+++ b/src/isLeapYear.js
@@ -1,6 +1,1 @@
-import curry from 'lodash.curry'
-import {check} from './helpers/util'
-
-const isLeapYear = date => new Date(`${date.getFullYear()}-02-29`).getMonth() === 1
-
-export default curry(date => check([date], isLeapYear, date))
+export default date => new Date(`${date.getFullYear()}-02-29`).getMonth() === 1

--- a/src/isValid.js
+++ b/src/isValid.js
@@ -1,4 +1,3 @@
 import {checkDate, checkNaN} from './helpers/util'
 
-export default date =>
-  checkDate(date) && checkNaN(date.getTime()) === false
+export default date => checkDate(date) && checkNaN(date.getTime()) === false

--- a/src/max.js
+++ b/src/max.js
@@ -1,4 +1,4 @@
-import curry from 'lodash.curry'
-import {find} from './helpers/util'
-
-export default curry(array => find(Math.max, array))
+import {find, any} from './helpers/util'
+import isValid from './isValid'
+export default dates =>
+  any(isValid, dates) ? find(Math.max, dates) : new Date('invalid')

--- a/src/set.js
+++ b/src/set.js
@@ -12,13 +12,11 @@ const setters = {
 }
 
 export default curry((step, value, date) => {
-  if (!setters.hasOwnProperty(step)) return new Error(`${step} is not a valid date step`)
+  if (!setters.hasOwnProperty(step)) return new Date('invalid')
 
   const clone = new Date(date.getTime())
 
   setters[step](value, clone)
 
-  if (get(step, clone) !== value) return new Error(`Invalid value for ${step}`)
-
-  return clone
+  return (get(step, clone) === value) ? clone : new Date('invalid')
 })


### PR DESCRIPTION
This means that our functions no longer break their type signatures when returning errors.
or said differently all functions (except parse) are now pure.
