### PR TITLE
Simplify Find Function Used by Min and Max

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "date-fp",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Functional programming date management.",
   "main": "build/date-fp.js",
   "dependencies": {

--- a/src/_spec/max.js
+++ b/src/_spec/max.js
@@ -29,6 +29,7 @@ describe('max', () => {
     assert(checkDate(actual))
     assert.equal(isValid(actual), false)
   })
+
   it('should return an invalid date when passed no dates', () => {
     const actual = max([invalidDate, invalidDate1])
 

--- a/src/_spec/max.js
+++ b/src/_spec/max.js
@@ -30,7 +30,7 @@ describe('max', () => {
     assert.equal(isValid(actual), false)
   })
 
-  it('should return an invalid date when passed no dates', () => {
+  it('should return an invalid date when passed only invalid dates', () => {
     const actual = max([invalidDate, invalidDate1])
 
     assert(checkDate(actual))

--- a/src/helpers/util.js
+++ b/src/helpers/util.js
@@ -8,15 +8,13 @@ export const lastN = curry((n, str) => str.substring(str.length - n, str.length)
 export const firstN = curry((n, str) => str.substring(0, n))
 export const fill = curry((digits, n) => lastN(digits, ZEROS + n))
 
-export const validate = dates => dates.length > 0 && dates.filter(isValid).length === dates.length
-export const check = (dates, f, ...args) => validate(dates) ? f(...args) : new Error('Invalid date object(s) provided.')
 export const find = curry((f, array) => {
   const filtered = array.filter(isValid)
 
-  return check(filtered, dates => new Date(dates.reduce((memo, date) => f(memo, date))), filtered)
+  return filtered.length === 0 ? new Date('invalid') : new Date(filtered.reduce((memo, date) => f(memo, date)))
 })
-export const any = curry((f, coll) => coll.reduce((r, e) => r || f(e), false))
 
+export const any = curry((f, coll) => coll.reduce((r, e) => r || f(e), false))
 
 export const checkNaN = n => n !== n // NaN is the only number that is not equal to itself
 


### PR DESCRIPTION
There was some redundant code leftover from when we used to return errors.
