### PR TITLE
Fix get timeZoneOffset test

### DIFF
--- a/src/_spec/get.js
+++ b/src/_spec/get.js
@@ -89,6 +89,6 @@ describe('get', () => {
     const input = new Date('2015-01-02 11:22:33.123')
     const timezoneOffset = get('timezoneOffset', input)
 
-    assert.equal(timezoneOffset, (new Date()).getTimezoneOffset())
+    assert.equal(timezoneOffset, input.getTimezoneOffset())
   })
 })


### PR DESCRIPTION
Make sure to check that the timezone offset to compare with is retreived
from the input date since the offset may vary during the year.
