### PR TITLE
Modularized built files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,16 @@
 {
   "name": "date-fp",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "description": "Functional programming date management.",
-  "main": "build/date-fp.js",
+  "main": "build/index.js",
   "dependencies": {
     "lodash.curry": "^3.0.2"
   },
   "scripts": {
     "webpack": "webpack src/index.js build/date-fp.js --config webpack.config.js",
     "uglify": "uglifyjs build/date-fp.js -o build/date-fp.min.js --source-map build/date-fp.min.map -p relative",
-    "build": "npm run webpack && npm run uglify",
+    "build": "npm run webpack && npm run uglify && npm run build:modules",
+    "build:modules": "babel src --out-dir build --ignore src/_spec",
     "test": "babel-node node_modules/.bin/isparta cover _mocha -- --compilers js:babel-register 'src/**/_spec/*.js'",
     "posttest": "istanbul check-coverage --branches 100",
     "testBuild": "mocha buildTest.js",


### PR DESCRIPTION
Release separated compiled-to-ES5 files, so consumers can required the only functions they need.

Result:

``` shell
> date-fp@4.4.1 build:modules /Users/mtk10835/date-fp
> babel src --out-dir build --ignore src/_spec

src/add.js -> build/add.js
src/convertTo.js -> build/convertTo.js
src/diff.js -> build/diff.js
src/equals.js -> build/equals.js
src/format.js -> build/format.js
src/get.js -> build/get.js
src/helpers/constants.js -> build/helpers/constants.js
src/helpers/util.js -> build/helpers/util.js
src/index.js -> build/index.js
src/isLeapYear.js -> build/isLeapYear.js
src/isValid.js -> build/isValid.js
src/max.js -> build/max.js
src/min.js -> build/min.js
src/parse.js -> build/parse.js
src/set.js -> build/set.js
src/sub.js -> build/sub.js
src/unixTime.js -> build/unixTime.js
```
