### PR TITLE
update tests to work in all timezones

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "date-fp",
-  "version": "4.4.3",
+  "version": "4.4.4",
   "description": "Functional programming date management.",
   "main": "build/index.js",
   "dependencies": {

--- a/src/_spec/add.js
+++ b/src/_spec/add.js
@@ -58,7 +58,7 @@ describe('add', () => {
   })
 
   it('should work for months', () => {
-    const actual = add('months', 1, new Date(0))
+    const actual = add('months', 1, new Date('2015-01-15'))
 
     assert.equal(1, actual.getMonth())
   })
@@ -78,7 +78,7 @@ describe('add', () => {
   })
 
   it('should work for year', () => {
-    const actual = add('years', 1, new Date(0))
+    const actual = add('years', 1, new Date('1970-06-15'))
 
     assert.equal(1971, actual.getFullYear())
   })

--- a/src/_spec/format.js
+++ b/src/_spec/format.js
@@ -138,6 +138,6 @@ describe('format', () => {
   })
 
   it('Q', () => {
-    assert.equal(format('Q', new Date('2015-10-01')), '4')
+    assert.equal(format('Q', new Date('2015-11-15')), '4')
   })
 })

--- a/src/_spec/isLeapYear.js
+++ b/src/_spec/isLeapYear.js
@@ -8,18 +8,18 @@ describe('isLeapYear', () => {
   })
 
   it('should return false for non leap years', () => {
-    assert.strictEqual(isLeapYear(new Date('2015-01-01')), false)
+    assert.strictEqual(isLeapYear(new Date('2015-06-01')), false)
   })
 
   it('should return true years divisible by 4', () => {
-    assert.strictEqual(isLeapYear(new Date('1996-01-01')), true)
+    assert.strictEqual(isLeapYear(new Date('1996-06-01')), true)
   })
 
   it('should return false for years divisible by 100', () => {
-    assert.strictEqual(isLeapYear(new Date('1900-01-01')), false)
+    assert.strictEqual(isLeapYear(new Date('1900-06-01')), false)
   })
 
   it('should return true for years divisible by 400', () => {
-    assert.strictEqual(isLeapYear(new Date('2000-01-01')), true)
+    assert.strictEqual(isLeapYear(new Date('2000-06-01')), true)
   })
 })

--- a/src/isLeapYear.js
+++ b/src/isLeapYear.js
@@ -1,1 +1,1 @@
-export default date => new Date(`${date.getFullYear()}-02-29`).getMonth() === 1
+export default date => new Date(date.getFullYear(), 1, 29).getMonth() === 1


### PR DESCRIPTION
Updated a couple tests so they work in all timezones.

Also a small change to `isLeapYear`. In my super comprehensive testing (my current versions of node, chrome and firefox), `new Date` consistently parses 'YYYY-MM-DD' strings as UTC, while 'YYYY-MM-DD HH:MM:SS' strings and the `Number -> Number -> Number -> Date` version consistently treat their arguments as local time. For me, `isLeapYear` would then have `${date.getFullYear()}-02-29` become `2015-03-01T00:00:00.000Z` in non-leap years, which is still February for negative offsets so `getMonth` will always return 1.

This of course will all sort itself out once #41 is resolved, but I've done my best to come up with a reasonable solution in the mean time.
