### PR TITLE
fix base-1 hour format functions to start from 1 instead of 0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "date-fp",
-  "version": "4.4.4",
+  "version": "4.4.5",
   "description": "Functional programming date management.",
   "main": "build/index.js",
   "dependencies": {

--- a/src/_spec/format.js
+++ b/src/_spec/format.js
@@ -83,10 +83,12 @@ describe('format', () => {
 
   it('hh', () => {
     assert.equal(format('hh', new Date('2015-03-04 22:08:05.023')), '10')
+    assert.equal(format('hh', new Date('2015-03-04 12:01:01')), '12');
   })
 
   it('h', () => {
     assert.equal(format('h', date), '9')
+    assert.equal(format('h', new Date('2015-03-04 12:01:01')), '12');
   })
 
   it('mm', () => {

--- a/src/format.js
+++ b/src/format.js
@@ -21,8 +21,8 @@ const tokenFunctions = {
   d: d => d.getDay(),
   HH: d => fill(2, d.getHours()),
   H: d => d.getHours(),
-  hh: d => fill(2, d.getHours() % 12),
-  h: d => d.getHours() % 12,
+  hh: d => fill(2, modCeiling(12, d.getHours())),
+  h: d => modCeiling(12, d.getHours()),
   mm: d => fill(2, d.getMinutes()),
   m: d => d.getMinutes(),
   ss: d => fill(2, d.getSeconds()),
@@ -34,6 +34,8 @@ const tokenFunctions = {
   S: d => firstN(1, fill(3, d.getMilliseconds())),
   Q: d => Math.ceil((d.getMonth() + 1) / 3),
 }
+
+const modCeiling = (mod, val) => val % mod || mod
 
 const swapTokenWithValue = curry((date, token) => tokenFunctions[token] ? tokenFunctions[token](date) : token)
 


### PR DESCRIPTION
`h` and `hh` were not starting from 1 as the docs claimed they were.
