### PR TITLE
Return 53 instead of 0 when the week belongs to previous year on getWeek

### DIFF
--- a/src/_spec/get.js
+++ b/src/_spec/get.js
@@ -71,6 +71,13 @@ describe('get', () => {
     assert.equal(week, 10)
   })
 
+  it('should return 53 when the week belongs to previous year', () => {
+    const input = new Date('2016-01-01 11:22:33.123')
+    const week = get('week', input)
+
+    assert.equal(week, 53)
+  })
+
   it('should return the month', () => {
     const input = new Date('2015-01-02 11:22:33.123')
     const month = get('month', input)

--- a/src/get.js
+++ b/src/get.js
@@ -12,7 +12,8 @@ const getWeek = _date => {
   date.setDate(date.getDate() + (7 - getWeekDay(date)))
   firstWeek.setDate(firstWeek.getDate() + (7 - getWeekDay(firstWeek)))
   // return the diff in weeks. add 1 because we are starting at week 1
-  return 1 + Math.round((date.getTime() - firstWeek.getTime()) / DATE_UNITS.weeks)
+  // when the math result is 0, return 53 instead
+  return 1 + Math.round((date.getTime() - firstWeek.getTime()) / DATE_UNITS.weeks) || 53
 }
 
 const getters = {


### PR DESCRIPTION
Return 53 instead of 0 when the week belongs to previous year on getWeek